### PR TITLE
Feat/organize graph

### DIFF
--- a/Editor Scripts/MovesetGraphEditor.cs
+++ b/Editor Scripts/MovesetGraphEditor.cs
@@ -1,7 +1,9 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
+using XNode;
 using XNodeEditor;
 
 namespace NASB_Moveset_Editor
@@ -104,5 +106,12 @@ namespace NASB_Moveset_Editor
 				graphParentName = graphPath;
 			}
 		}
+
+        public override void AddContextMenuItems(GenericMenu menu, Type compatibleType = null, NodePort.IO direction = NodePort.IO.Input)
+        {
+            base.AddContextMenuItems(menu, compatibleType, direction);
+			menu.AddSeparator("");
+			menu.AddItem(new GUIContent("Organize Graph"), false, () => Utils.CheckOrganizeGraph());
+        }
     }
 }

--- a/Editor Scripts/MovesetGraphEditor.cs
+++ b/Editor Scripts/MovesetGraphEditor.cs
@@ -111,7 +111,7 @@ namespace NASB_Moveset_Editor
         {
             base.AddContextMenuItems(menu, compatibleType, direction);
 			menu.AddSeparator("");
-			menu.AddItem(new GUIContent("Organize Graph"), false, () => Utils.CheckOrganizeGraph());
+			menu.AddItem(new GUIContent("Organize Graph"), false, () => GraphHandler.CheckOrganizeGraph());
         }
     }
 }

--- a/Scripts/GraphHandler.cs
+++ b/Scripts/GraphHandler.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System;
 using System.Collections.Generic;
 using XNode;
+using XNodeEditor;
 
 namespace NASB_Moveset_Editor
 {
@@ -206,26 +207,28 @@ namespace NASB_Moveset_Editor
             Undo.RecordObjects(nodes.ToArray(), "Organize Graph");
 
             // Travel through outputs and position nodes
-            TraverseThroughOutputs(idStateNode, Vector2.zero);
+            TraverseThroughOutputsHeight(idStateNode, Vector2.zero);
             Logger.LogInfo($"Organized graph!");
         }
 
-        private static int TraverseThroughOutputs(Node node, Vector2 nodeDepthXY)
+        private static float TraverseThroughOutputsHeight(Node node, Vector2 nodePos)
         {
-            // Move this node
-            node.position.x = nodeDepthXY.x * Consts.NodeXOffset;
-            node.position.y = nodeDepthXY.y * Consts.NodeYOffset;
-            int outputPortCount = 0;
+            node.position.x = nodePos.x;
+            node.position.y = nodePos.y;
+
+            Vector2 nodeSize = NodeEditorWindow.current.nodeSizes[node];
+
+            float heightOffset = 0;
             foreach (NodePort port in node.Outputs)
             {
                 foreach (NodePort connectedPort in port.GetConnections())
                 {
-                    outputPortCount += TraverseThroughOutputs(connectedPort.node, nodeDepthXY + new Vector2(1, outputPortCount));
+                    float tempHeight = TraverseThroughOutputsHeight(connectedPort.node, nodePos + new Vector2(Consts.NodeXOffset, heightOffset));
+                    heightOffset += tempHeight;
                 }
-                ++outputPortCount;
             }
 
-            return outputPortCount > 0 ? outputPortCount - 1 : outputPortCount;
+            return heightOffset > nodeSize.y ? heightOffset : nodeSize.y;
         }
     }
 }

--- a/Scripts/GraphHandler.cs
+++ b/Scripts/GraphHandler.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using XNode;
 using XNodeEditor;
+using NASB_Moveset_Editor.StateActions;
 
 namespace NASB_Moveset_Editor
 {
@@ -219,13 +220,37 @@ namespace NASB_Moveset_Editor
             Vector2 nodeSize = NodeEditorWindow.current.nodeSizes[node];
 
             float heightOffset = 0;
+            Node previousConnectedNode = null;
+            float savedY = 0;
+            int portCount = 0;
             foreach (NodePort port in node.Outputs)
             {
                 foreach (NodePort connectedPort in port.GetConnections())
                 {
-                    float tempHeight = TraverseThroughOutputsHeight(connectedPort.node, nodePos + new Vector2(Consts.NodeXOffset, heightOffset));
+                    float tempHeight = 0;
+                    if (previousConnectedNode != null
+                        && connectedPort.node.GetType().Equals(typeof(SAConfigHitboxNode))
+                        && !previousConnectedNode.GetType().Equals(typeof(SAConfigHitboxNode)))
+                    {
+                        savedY = heightOffset;
+                        Vector2 offset = nodePos + new Vector2(Consts.NodeXOffset * portCount, heightOffset);
+                        heightOffset = TraverseThroughOutputsHeight(connectedPort.node, offset);
+                    }
+                    else if (previousConnectedNode != null
+                        && connectedPort.node.GetType().Equals(typeof(SAConfigHitboxNode))
+                        && previousConnectedNode.GetType().Equals(typeof(SAConfigHitboxNode)))
+                    {
+                        Vector2 offset = nodePos + new Vector2(Consts.NodeXOffset * portCount, savedY);
+                        TraverseThroughOutputsHeight(connectedPort.node, offset);
+                    }
+                    else
+                    {
+                        tempHeight = TraverseThroughOutputsHeight(connectedPort.node, nodePos + new Vector2(Consts.NodeXOffset, heightOffset));
+                    }
+                    previousConnectedNode = connectedPort.node;
                     heightOffset += tempHeight;
                 }
+                ++portCount;
             }
 
             return heightOffset > nodeSize.y ? heightOffset : nodeSize.y;

--- a/Scripts/GraphHandler.cs
+++ b/Scripts/GraphHandler.cs
@@ -212,7 +212,7 @@ namespace NASB_Moveset_Editor
             Logger.LogInfo($"Organized graph!");
         }
 
-        private static float TraverseThroughOutputsHeight(Node node, Vector2 nodePos)
+        private static Vector2 TraverseThroughOutputsHeight(Node node, Vector2 nodePos)
         {
             node.position.x = nodePos.x;
             node.position.y = nodePos.y;
@@ -229,7 +229,7 @@ namespace NASB_Moveset_Editor
             {
                 foreach (NodePort connectedPort in port.GetConnections())
                 {
-                    float tempHeight = 0;
+                    Vector2 temp = Vector2.zero;
 
                     if(connectedPort.node.GetType().Equals(typeof(SAConfigHitboxNode)) && previousConnectedNode != null)
                     {
@@ -241,20 +241,20 @@ namespace NASB_Moveset_Editor
                         {
                             savedY = heightOffset;
                             Vector2 offset = nodePos + new Vector2(Consts.NodeXOffset * portCount, heightOffset);
-                            tempHeight = TraverseThroughOutputsHeight(connectedPort.node, offset);
+                            temp = TraverseThroughOutputsHeight(connectedPort.node, offset);
                         }
                     } else
                     {
-                        tempHeight = TraverseThroughOutputsHeight(connectedPort.node, nodePos + new Vector2(Consts.NodeXOffset, heightOffset));
+                        temp = TraverseThroughOutputsHeight(connectedPort.node, nodePos + new Vector2(Consts.NodeXOffset, heightOffset));
                     }
 
                     previousConnectedNode = connectedPort.node;
-                    heightOffset += tempHeight;
+                    heightOffset += temp.y;
                 }
                 ++portCount;
             }
 
-            return heightOffset > nodeSize.y ? heightOffset : nodeSize.y;
+            return new Vector2 (nodePos.x, heightOffset > nodeSize.y ? heightOffset : nodeSize.y);
         }
     }
 }

--- a/Scripts/GraphHandler.cs
+++ b/Scripts/GraphHandler.cs
@@ -225,7 +225,7 @@ namespace NASB_Moveset_Editor
                 ++outputPortCount;
             }
 
-            return outputPortCount;
+            return outputPortCount > 0 ? outputPortCount - 1 : outputPortCount;
         }
     }
 }

--- a/Scripts/GraphHandler.cs
+++ b/Scripts/GraphHandler.cs
@@ -219,34 +219,35 @@ namespace NASB_Moveset_Editor
 
             Vector2 nodeSize = NodeEditorWindow.current.nodeSizes[node];
 
-            float heightOffset = 0;
+            // Special variables used for SAConfigHitboxNode
             Node previousConnectedNode = null;
             float savedY = 0;
+
+            float heightOffset = 0;
             int portCount = 0;
             foreach (NodePort port in node.Outputs)
             {
                 foreach (NodePort connectedPort in port.GetConnections())
                 {
                     float tempHeight = 0;
-                    if (previousConnectedNode != null
-                        && connectedPort.node.GetType().Equals(typeof(SAConfigHitboxNode))
-                        && !previousConnectedNode.GetType().Equals(typeof(SAConfigHitboxNode)))
+
+                    if(connectedPort.node.GetType().Equals(typeof(SAConfigHitboxNode)) && previousConnectedNode != null)
                     {
-                        savedY = heightOffset;
-                        Vector2 offset = nodePos + new Vector2(Consts.NodeXOffset * portCount, heightOffset);
-                        heightOffset = TraverseThroughOutputsHeight(connectedPort.node, offset);
-                    }
-                    else if (previousConnectedNode != null
-                        && connectedPort.node.GetType().Equals(typeof(SAConfigHitboxNode))
-                        && previousConnectedNode.GetType().Equals(typeof(SAConfigHitboxNode)))
-                    {
-                        Vector2 offset = nodePos + new Vector2(Consts.NodeXOffset * portCount, savedY);
-                        TraverseThroughOutputsHeight(connectedPort.node, offset);
-                    }
-                    else
+                        if (previousConnectedNode.GetType().Equals(typeof(SAConfigHitboxNode)))
+                        {
+                            Vector2 offset = nodePos + new Vector2(Consts.NodeXOffset * portCount, savedY);
+                            TraverseThroughOutputsHeight(connectedPort.node, offset);
+                        } else
+                        {
+                            savedY = heightOffset;
+                            Vector2 offset = nodePos + new Vector2(Consts.NodeXOffset * portCount, heightOffset);
+                            tempHeight = TraverseThroughOutputsHeight(connectedPort.node, offset);
+                        }
+                    } else
                     {
                         tempHeight = TraverseThroughOutputsHeight(connectedPort.node, nodePos + new Vector2(Consts.NodeXOffset, heightOffset));
                     }
+
                     previousConnectedNode = connectedPort.node;
                     heightOffset += tempHeight;
                 }

--- a/Scripts/GraphHandler.cs
+++ b/Scripts/GraphHandler.cs
@@ -221,40 +221,44 @@ namespace NASB_Moveset_Editor
 
             // Special variables used for SAConfigHitboxNode
             Node previousConnectedNode = null;
-            float savedY = 0;
+            float savedYPos = 0;
 
             float heightOffset = 0;
+            float widthOffset = 0;
             int portCount = 0;
             foreach (NodePort port in node.Outputs)
             {
                 foreach (NodePort connectedPort in port.GetConnections())
                 {
-                    Vector2 temp = Vector2.zero;
+                    Vector2 branchDepth = Vector2.zero;
 
                     if(connectedPort.node.GetType().Equals(typeof(SAConfigHitboxNode)) && previousConnectedNode != null)
                     {
                         if (previousConnectedNode.GetType().Equals(typeof(SAConfigHitboxNode)))
                         {
-                            Vector2 offset = nodePos + new Vector2(Consts.NodeXOffset * portCount, savedY);
+                            Vector2 offset = nodePos + new Vector2(Consts.NodeXOffset * portCount, savedYPos);
                             TraverseThroughOutputsHeight(connectedPort.node, offset);
                         } else
                         {
-                            savedY = heightOffset;
+                            savedYPos = heightOffset;
                             Vector2 offset = nodePos + new Vector2(Consts.NodeXOffset * portCount, heightOffset);
-                            temp = TraverseThroughOutputsHeight(connectedPort.node, offset);
+                            branchDepth = TraverseThroughOutputsHeight(connectedPort.node, offset);
                         }
                     } else
                     {
-                        temp = TraverseThroughOutputsHeight(connectedPort.node, nodePos + new Vector2(Consts.NodeXOffset, heightOffset));
+                        branchDepth = TraverseThroughOutputsHeight(connectedPort.node, nodePos + new Vector2(Consts.NodeXOffset, heightOffset));
                     }
 
                     previousConnectedNode = connectedPort.node;
-                    heightOffset += temp.y;
+                    heightOffset += branchDepth.y;
+                    widthOffset = branchDepth.x;
+                    if (widthOffset > nodePos.x + Consts.NodeXOffset) 
+                        heightOffset += Consts.NodeClusterYSpacing;
                 }
                 ++portCount;
             }
 
-            return new Vector2 (nodePos.x, heightOffset > nodeSize.y ? heightOffset : nodeSize.y);
+            return new Vector2 (widthOffset + nodePos.x, heightOffset > nodeSize.y ? heightOffset : nodeSize.y);
         }
     }
 }

--- a/Scripts/GraphHandler.cs
+++ b/Scripts/GraphHandler.cs
@@ -181,6 +181,7 @@ namespace NASB_Moveset_Editor
             if (EditorUtility.DisplayDialog("Organize Graph", "Are you sure you want to organize the entire graph?", "Yes", "No"))
             {
                 OrganizeGraph();
+                XNodeEditor.NodeEditorWindow.DrawAllNodesOnce();
             }
         }
 

--- a/Scripts/NSABMovesetEditorTesting.cs
+++ b/Scripts/NSABMovesetEditorTesting.cs
@@ -59,7 +59,7 @@ namespace NASB_Moveset_Editor
                     EditorGUILayout.Space(10);
                     if (GUILayout.Button("Organize Graph", GUILayout.MinHeight(35)))
                     {
-                        Utils.OrganizeGraph();
+                        Utils.CheckOrganizeGraph();
                     }
                     EditorGUILayout.Space(10);
                 }

--- a/Scripts/NSABMovesetEditorTesting.cs
+++ b/Scripts/NSABMovesetEditorTesting.cs
@@ -59,7 +59,7 @@ namespace NASB_Moveset_Editor
                     EditorGUILayout.Space(10);
                     if (GUILayout.Button("Organize Graph", GUILayout.MinHeight(35)))
                     {
-                        Utils.CheckOrganizeGraph();
+                        GraphHandler.CheckOrganizeGraph();
                     }
                     EditorGUILayout.Space(10);
                 }

--- a/Scripts/NSABMovesetEditorTesting.cs
+++ b/Scripts/NSABMovesetEditorTesting.cs
@@ -4,6 +4,8 @@ using UnityEngine;
 using XNodeEditor;
 using XNode;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace NASB_Moveset_Editor
 {
@@ -53,6 +55,11 @@ namespace NASB_Moveset_Editor
                             Logger.LogError("Could not find characterBase. Have you imported the characterBase asset?");
                             Logger.LogError(e.Message);
                         }
+                    }
+                    EditorGUILayout.Space(10);
+                    if (GUILayout.Button("Organize Graph", GUILayout.MinHeight(35)))
+                    {
+                        Utils.OrganizeGraph();
                     }
                     EditorGUILayout.Space(10);
                 }

--- a/Scripts/Utils/Utils.cs
+++ b/Scripts/Utils/Utils.cs
@@ -74,7 +74,15 @@ namespace NASB_Moveset_Editor
             return scriptPath;
         }
 
-        public static void OrganizeGraph()
+        public static void CheckOrganizeGraph()
+        {
+            if (EditorUtility.DisplayDialog("Organize Graph", "Are you sure you want to organize the entire graph?", "Yes", "No"))
+            {
+                OrganizeGraph();
+            }
+        }
+
+        private static void OrganizeGraph()
         {
             // Get all the nodes from the current graph
             List<Node> nodes = XNodeEditor.NodeEditorWindow.current.graph.nodes;
@@ -95,8 +103,11 @@ namespace NASB_Moveset_Editor
                 return;
             }
 
+            Undo.RecordObjects(nodes.ToArray(), "Organize Graph");
+
             // Travel through outputs and position nodes
             TraverseThroughOutputs(idStateNode, Vector2.zero);
+            Logger.LogInfo($"Organized graph!");
         }
 
         private static int TraverseThroughOutputs(Node node, Vector2 nodeDepthXY)

--- a/Scripts/Utils/Utils.cs
+++ b/Scripts/Utils/Utils.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using UnityEditor;
 using UnityEngine;
+using XNode;
 
 namespace NASB_Moveset_Editor
 {
@@ -71,6 +72,49 @@ namespace NASB_Moveset_Editor
                 }
             }
             return scriptPath;
+        }
+
+        public static void OrganizeGraph()
+        {
+            // Get all the nodes from the current graph
+            List<Node> nodes = XNodeEditor.NodeEditorWindow.current.graph.nodes;
+
+            // Find idstate node
+            IdStateNode idStateNode = null;
+            foreach (Node node in nodes)
+            {
+                if (node.GetType().Equals(typeof(IdStateNode)))
+                {
+                    idStateNode = (IdStateNode)node;
+                }
+            }
+
+            if (idStateNode == null)
+            {
+                Logger.LogError("Could not find IdStateNode in graph!");
+                return;
+            }
+
+            // Travel through outputs and position nodes
+            TraverseThroughOutputs(idStateNode, Vector2.zero);
+        }
+
+        private static int TraverseThroughOutputs(Node node, Vector2 nodeDepthXY)
+        {
+            // Move this node
+            node.position.x = nodeDepthXY.x * Consts.NodeXOffset;
+            node.position.y = nodeDepthXY.y * Consts.NodeYOffset;
+            int outputPortCount = 0;
+            foreach (NodePort port in node.Outputs)
+            {
+                foreach (NodePort connectedPort in port.GetConnections())
+                {
+                    outputPortCount += TraverseThroughOutputs(connectedPort.node, nodeDepthXY + new Vector2(1, outputPortCount));
+                }
+                ++outputPortCount;
+            }
+
+            return outputPortCount;
         }
     }
 

--- a/Scripts/Utils/Utils.cs
+++ b/Scripts/Utils/Utils.cs
@@ -73,60 +73,6 @@ namespace NASB_Moveset_Editor
             }
             return scriptPath;
         }
-
-        public static void CheckOrganizeGraph()
-        {
-            if (EditorUtility.DisplayDialog("Organize Graph", "Are you sure you want to organize the entire graph?", "Yes", "No"))
-            {
-                OrganizeGraph();
-            }
-        }
-
-        private static void OrganizeGraph()
-        {
-            // Get all the nodes from the current graph
-            List<Node> nodes = XNodeEditor.NodeEditorWindow.current.graph.nodes;
-
-            // Find idstate node
-            IdStateNode idStateNode = null;
-            foreach (Node node in nodes)
-            {
-                if (node.GetType().Equals(typeof(IdStateNode)))
-                {
-                    idStateNode = (IdStateNode)node;
-                }
-            }
-
-            if (idStateNode == null)
-            {
-                Logger.LogError("Could not find IdStateNode in graph!");
-                return;
-            }
-
-            Undo.RecordObjects(nodes.ToArray(), "Organize Graph");
-
-            // Travel through outputs and position nodes
-            TraverseThroughOutputs(idStateNode, Vector2.zero);
-            Logger.LogInfo($"Organized graph!");
-        }
-
-        private static int TraverseThroughOutputs(Node node, Vector2 nodeDepthXY)
-        {
-            // Move this node
-            node.position.x = nodeDepthXY.x * Consts.NodeXOffset;
-            node.position.y = nodeDepthXY.y * Consts.NodeYOffset;
-            int outputPortCount = 0;
-            foreach (NodePort port in node.Outputs)
-            {
-                foreach (NodePort connectedPort in port.GetConnections())
-                {
-                    outputPortCount += TraverseThroughOutputs(connectedPort.node, nodeDepthXY + new Vector2(1, outputPortCount));
-                }
-                ++outputPortCount;
-            }
-
-            return outputPortCount;
-        }
     }
 
     public static class Logger

--- a/Scripts/Utils/Utils.cs
+++ b/Scripts/Utils/Utils.cs
@@ -109,6 +109,7 @@ namespace NASB_Moveset_Editor
     {
         public const float NodeXOffset = 250f;
         public const float NodeYOffset = 130f;
+        public const float NodeClusterYSpacing = 50f;
         public const float NodeVarHeight = 20f;
         public const int MaxDisplayNameLength = 12;
 


### PR DESCRIPTION
Closes #14 

- New option to organize graph in right-click menu.
![image](https://user-images.githubusercontent.com/27714637/144152510-189f34cf-0cc0-44b4-a843-70f28b3d6a0d.png)

- Clicking the "Organize Graph" option opens a dialog prompt to confirm
- The action is undo-able
- When organizing the graph, node height is taken into account
- Special horizontal spacing for consecutive SAConfigHitbox nodes

![image](https://user-images.githubusercontent.com/27714637/144152548-f4ff8877-ec4f-4990-94ad-aef97b46d272.png)





Graphs generated from importing a text asset will still be organized using the old method when first imported. The node height data is not available unless the graph is actually open in the editor window (as far as I can tell).

In the future it might be possible to detect if a generated graph is being opened for the first time, and apply the organization method to it.